### PR TITLE
Add customer name population functionality in order histories</message>

### DIFF
--- a/app/Console/Commands/PopulateCustomerNames.php
+++ b/app/Console/Commands/PopulateCustomerNames.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class PopulateCustomerNames extends Command
+{
+    protected $signature = 'orders:populate-customer-names';
+    protected $description = 'Populate customer names in order histories table';
+
+    public function handle()
+    {
+        $this->info('Starting to populate customer names...');
+
+        DB::table('order_histories as oh')
+            ->join('customers as c', 'oh.customer_id', '=', 'c.id')
+            ->whereNull('oh.customer_name')
+            ->update(['oh.customer_name' => DB::raw('c.fullname')]);
+
+        $this->info('Customer names populated successfully!');
+    }
+} 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        Commands\PopulateCustomerNames::class,
     ];
 
     /**

--- a/app/Models/OrderHistory.php
+++ b/app/Models/OrderHistory.php
@@ -3,16 +3,54 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Customer;
+use Illuminate\Support\Facades\Log;
 
 class OrderHistory extends Model
 {
     protected $fillable = [
         'customer_id',
+        'customer_name',
         'description',
         'received_on',
         'amount_charged',
+        'processed_by',
         'staff_id'
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($orderHistory) {
+            Log::info('Creating OrderHistory record', [
+                'customer_id' => $orderHistory->customer_id,
+                'customer_name' => $orderHistory->customer_name
+            ]);
+
+            if ($orderHistory->customer_id) {
+                $customer = Customer::find($orderHistory->customer_id);
+                Log::info('Found customer', [
+                    'customer' => $customer ? $customer->toArray() : null
+                ]);
+
+                if ($customer) {
+                    $orderHistory->customer_name = $customer->fullname;
+                    Log::info('Set customer_name', [
+                        'customer_name' => $orderHistory->customer_name
+                    ]);
+                }
+            }
+        });
+
+        static::created(function ($orderHistory) {
+            Log::info('OrderHistory record created', [
+                'id' => $orderHistory->id,
+                'customer_id' => $orderHistory->customer_id,
+                'customer_name' => $orderHistory->customer_name
+            ]);
+        });
+    }
 
     public function customer()
     {

--- a/resources/views/order_history.blade.php
+++ b/resources/views/order_history.blade.php
@@ -79,7 +79,7 @@
                                     @foreach ($orders as $index => $order)
                                         <tr>
                                             <td>{{$index + 1}}</td>
-                                            <td>{{$order->customer ? $order->customer->fullname : '-'}}</td>
+                                            <td>{{$order->customer_name ?? ($order->customer ? $order->customer->fullname : '-')}}</td>
                                             <td>{{$order->description}}</td>
                                             <td>{{$order->received_on}}</td>
                                             <td>RM {{number_format($order->amount_charged, 2)}}</td>


### PR DESCRIPTION
<message>
- Introduced a new console command `orders:populate-customer-names` to populate customer names in the order histories table.
- Updated the `RetentionController` to store customer names in order histories during order deletion.
- Enhanced the `OrderHistory` model to automatically set the customer name upon creation.
- Modified the `Orders` model to create order history records when an order is marked as paid, ensuring customer names are captured.
- Updated the order history view to display customer names directly from the order history data, improving clarity for users.